### PR TITLE
Allow LVM to scan trusted crypt-plain devices

### DIFF
--- a/lvm2-set-default-global_filter.patch
+++ b/lvm2-set-default-global_filter.patch
@@ -2,15 +2,19 @@ diff --git a/conf/example.conf.in b/conf/example.conf.in
 index a29caf3..6a18999 100644
 --- a/conf/example.conf.in
 +++ b/conf/example.conf.in
-@@ -164,7 +164,11 @@ devices {
+@@ -164,7 +164,15 @@ devices {
  	# The syntax is the same as devices/filter. Devices rejected by
  	# global_filter are not opened by LVM.
  	# This configuration option has an automatic default value.
 -	# global_filter = [ "a|.*|" ]
-+	# global_filter = [ "a|^/dev/disk/by-id/dm-uuid-CRYPT-LUKS[12]-.*|",
-+	#                   "a|^/dev/nvme.*|",
-+	#                   "a|^/dev/sd.*|",
-+	#                   "a|^/dev/md.*|",
++	# global_filter = [ "a|^/dev/disk/by-id/dm-uuid-CRYPT-LUKS[12]-|",
++	#                   "a|^/dev/nvme[0-9]+n[0-9]+(p[0-9]+)?$|",
++	#                   "a|^/dev/sd[a-z]+[0-9]*$|",
++	#                   "a|^/dev/md[0-9]+(p[0-9]+)?$|",
++	#                   "r|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-qubes|",
++	#                   "r|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-vm|",
++	#                   "r|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-.*@crypt$|",
++	#                   "a|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-trusted-crypt-|",
 +	#                   "r|.*|" ]
  
  	# Configuration option devices/types.
@@ -19,16 +23,20 @@ diff --git a/lib/config/config_settings.h b/lib/config/config_settings.h
 index f280156..6911eab 100644
 --- a/lib/config/config_settings.h
 +++ b/lib/config/config_settings.h
-@@ -317,7 +317,12 @@ cfg_array(devices_filter_CFG, "filter", devices_CFG_SECTION, CFG_DEFAULT_COMMENT
+@@ -317,7 +317,16 @@ cfg_array(devices_filter_CFG, "filter", devices_CFG_SECTION, CFG_DEFAULT_COMMENT
  	"filter = [ \"a|^/dev/hda8$|\", \"r|.*|\" ]\n"
  	"#\n")
  
 -cfg_array(devices_global_filter_CFG, "global_filter", devices_CFG_SECTION, CFG_DEFAULT_COMMENTED, CFG_TYPE_STRING, "#Sa|.*|", vsn(2, 2, 98), NULL, 0, NULL,
 +cfg_array(devices_global_filter_CFG, "global_filter", devices_CFG_SECTION, CFG_DEFAULT_COMMENTED, CFG_TYPE_STRING,
-+    "#Sa|^/dev/disk/by-id/dm-uuid-CRYPT-LUKS[12]-.*|"
-+    "#Sa|^/dev/nvme.*|"
-+    "#Sa|^/dev/sd.*|"
-+    "#Sa|^/dev/md.*|"
++    "#Sa|^/dev/disk/by-id/dm-uuid-CRYPT-LUKS[12]-|"
++    "#Sa|^/dev/nvme[0-9]+n[0-9]+(p[0-9]+)?$|"
++    "#Sa|^/dev/sd[a-z]+[0-9]*$|"
++    "#Sa|^/dev/md[0-9]+(p[0-9]+)?$|"
++    "#Sr|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-qubes|"
++    "#Sr|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-vm|"
++    "#Sr|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-.*@crypt$|"
++    "#Sa|^/dev/disk/by-id/dm-uuid-CRYPT-PLAIN-trusted-crypt-|"
 +    "#Sr|.*|", vsn(2, 2, 98), NULL, 0, NULL,
  	"Limit the block devices that are used by LVM system components.\n"
  	"Because devices/filter may be overridden from the command line, it is\n"


### PR DESCRIPTION
Previously, this was not allowed, which broke legitimate uses.

Fixes QubesOS/qubes-issues#7344.