### PR TITLE
Add several useful patches

### DIFF
--- a/0001-dmsetup-splitname-udevflags-check-for-stdout-errors.patch
+++ b/0001-dmsetup-splitname-udevflags-check-for-stdout-errors.patch
@@ -1,0 +1,36 @@
+From fefc8d8bef4d6366d8df8d54e65925201035981b Mon Sep 17 00:00:00 2001
+Message-Id: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 1 Apr 2022 17:52:44 -0400
+Subject: [PATCH 1/6] dmsetup [splitname|udevflags]: check for stdout errors
+
+If there is an I/O error on stdout, return a non-zero status so that
+udev can avoid trusting the values printed.  Deeper changes to the
+log code are out of scope for this patch.
+---
+ libdm/dm-tools/dmsetup.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/libdm/dm-tools/dmsetup.c b/libdm/dm-tools/dmsetup.c
+index d01b8f2e8ef3038eac2337636d27a17bb47b9d76..5828ea7057d64d74286780467c708120aa191bb5 100644
+--- a/libdm/dm-tools/dmsetup.c
++++ b/libdm/dm-tools/dmsetup.c
+@@ -7471,6 +7471,13 @@ doit:
+ 					goto_out;
+ 				}
+ 			}
++
++			if ((!strcmp(cmd->name, "splitname") || !strcmp(cmd->name, "udevflags")) &&
++			    (fflush(stdout) || ferror(stdout))) {
++				log_error("Error writing to stdout");
++				ret = 1;
++				goto_out;
++			}
+ 		}
+ 
+ 		if (!r) {
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/0002-Disable-lvm2-udev-rules-if-dmsetup-splitname-fails.patch
+++ b/0002-Disable-lvm2-udev-rules-if-dmsetup-splitname-fails.patch
@@ -1,0 +1,32 @@
+From 38b4e9f1ed185ee68567381cb51e0b053b6702f2 Mon Sep 17 00:00:00 2001
+Message-Id: <c4972f51986d3d2625618e7162bf41df69bf3388.1666072612.git.demi@invisiblethingslab.com>
+In-Reply-To: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+References: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 1 Apr 2022 17:53:29 -0400
+Subject: [PATCH 2/6] Disable lvm2 udev rules if `dmsetup splitname` fails
+
+If `dmsetup splitname` cannot be run, or if its output cannot be
+trusted, the safest option is to disable all lvm2 udev rules.
+---
+ udev/11-dm-lvm.rules.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/udev/11-dm-lvm.rules.in b/udev/11-dm-lvm.rules.in
+index 7c589943b7d3de902fbca28c98ef58531e5aae8e..f7066b7dd592bbe30371988366c100716a594eaa 100644
+--- a/udev/11-dm-lvm.rules.in
++++ b/udev/11-dm-lvm.rules.in
+@@ -18,7 +18,7 @@ ENV{DM_UDEV_RULES_VSN}!="?*", GOTO="lvm_end"
+ ENV{DM_UUID}!="LVM-?*", GOTO="lvm_end"
+ 
+ # Use DM name and split it up into its VG/LV/layer constituents.
+-IMPORT{program}="(DM_EXEC)/dmsetup splitname --nameprefixes --noheadings --rows $env{DM_NAME}"
++IMPORT{program}!="(DM_EXEC)/dmsetup splitname --nameprefixes --noheadings --rows $env{DM_NAME}", GOTO="lvm_disable"
+ 
+ # DM_SUBSYSTEM_UDEV_FLAG0 is the 'NOSCAN' flag for LVM subsystem.
+ # This flag is used to temporarily disable selected rules to prevent any
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/0003-Disable-udev-rules-if-udev-flags-can-t-be-obtained.patch
+++ b/0003-Disable-udev-rules-if-udev-flags-can-t-be-obtained.patch
@@ -1,0 +1,32 @@
+From 2b9c38a4c2497b5b37bba3fd6f49c9ae270fd021 Mon Sep 17 00:00:00 2001
+Message-Id: <24ee88f9dddc407c56de1971753b05ff18f0b3b5.1666072612.git.demi@invisiblethingslab.com>
+In-Reply-To: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+References: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 1 Apr 2022 18:15:18 -0400
+Subject: [PATCH 3/6] Disable udev rules if udev flags can't be obtained
+
+In this cased the safest option is to disable most device-mapper udev
+rules.  This can only happen if `dmsetup udevflags` fails.
+---
+ udev/10-dm.rules.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/udev/10-dm.rules.in b/udev/10-dm.rules.in
+index b4fa52ab766effb04fc198fd52e6181ad5758eef..9fae8df95d1f2f36a4f7a4d92201e88f11aa6120 100644
+--- a/udev/10-dm.rules.in
++++ b/udev/10-dm.rules.in
+@@ -50,7 +50,7 @@ ACTION!="add|change", GOTO="dm_end"
+ # These flags are encoded in DM_COOKIE variable that was introduced in
+ # kernel version 2.6.31. Therefore, we can use this feature with
+ # kernels >= 2.6.31 only. Cookie is not decoded for remove event.
+-ENV{DM_COOKIE}=="?*", IMPORT{program}="(DM_EXEC)/dmsetup udevflags $env{DM_COOKIE}"
++ENV{DM_COOKIE}=="?*", IMPORT{program}!="(DM_EXEC)/dmsetup udevflags $env{DM_COOKIE}", GOTO="dm_disable"
+ 
+ # Rule out easy-to-detect inappropriate events first.
+ ENV{DISK_RO}=="1", GOTO="dm_disable"
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/0004-Drop-support-for-very-old-kernels.patch
+++ b/0004-Drop-support-for-very-old-kernels.patch
@@ -1,0 +1,55 @@
+From 39da6232ca947a4000afdfd5e10d2bb756bcda88 Mon Sep 17 00:00:00 2001
+Message-Id: <73851f5f37d977081224c5274824f138177a9193.1666072612.git.demi@invisiblethingslab.com>
+In-Reply-To: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+References: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 1 Apr 2022 18:16:24 -0400
+Subject: [PATCH 4/6] Drop support for very old kernels
+
+All kernels Qubes OS uses are new enough to have the dm/ subdirectory.
+The path for ancient kernels (before 2.6.31) did not check for dmsetup
+failing.
+---
+ udev/10-dm.rules.in | 17 ++++-------------
+ 1 file changed, 4 insertions(+), 13 deletions(-)
+
+diff --git a/udev/10-dm.rules.in b/udev/10-dm.rules.in
+index 9fae8df95d1f2f36a4f7a4d92201e88f11aa6120..93b7d10e16387d3c6177ea18e2b14e8f0c4be8e5 100644
+--- a/udev/10-dm.rules.in
++++ b/udev/10-dm.rules.in
+@@ -47,9 +47,6 @@ KERNEL!="dm-[0-9]*", GOTO="dm_end"
+ ACTION!="add|change", GOTO="dm_end"
+ 
+ # Decode udev control flags and set environment variables appropriately.
+-# These flags are encoded in DM_COOKIE variable that was introduced in
+-# kernel version 2.6.31. Therefore, we can use this feature with
+-# kernels >= 2.6.31 only. Cookie is not decoded for remove event.
+ ENV{DM_COOKIE}=="?*", IMPORT{program}!="(DM_EXEC)/dmsetup udevflags $env{DM_COOKIE}", GOTO="dm_disable"
+ 
+ # Rule out easy-to-detect inappropriate events first.
+@@ -104,16 +101,10 @@ LABEL="dm_no_coldplug"
+ #   |_ dev still not active            0                        0
+ #   \_ dev already active              1                        0
+ 
+-# "dm" sysfs subdirectory is available in newer versions of DM
+-# only (kernels >= 2.6.29). We have to check for its existence
+-# and use dmsetup tool instead to get the DM name, uuid and 
+-# suspended state if the "dm" subdirectory is not present.
+-# The "suspended" item was added even later (kernels >= 2.6.31),
+-# so we also have to call dmsetup if the kernel version used
+-# is in between these releases.
+-TEST=="dm", ENV{DM_NAME}="$attr{dm/name}", ENV{DM_UUID}="$attr{dm/uuid}", ENV{DM_SUSPENDED}="$attr{dm/suspended}"
+-TEST!="dm", IMPORT{program}="(DM_EXEC)/dmsetup info -j %M -m %m -c --nameprefixes --noheadings --rows -o name,uuid,suspended"
+-ENV{DM_SUSPENDED}!="?*", IMPORT{program}="(DM_EXEC)/dmsetup info -j %M -m %m -c --nameprefixes --noheadings --rows -o suspended"
++# Kernels older than 2.6.31 do not have dm/suspended sysfs attribute and are not
++# supported
++ENV{DM_NAME}="$attr{dm/name}", ENV{DM_UUID}="$attr{dm/uuid}", ENV{DM_SUSPENDED}="$attr{dm/suspended}"
++ENV{DM_SUSPENDED}!="?*", GOTO="dm_disable"
+ 
+ # dmsetup tool provides suspended state information in textual
+ # form with values "Suspended"/"Active". We translate it to
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/0005-Allow-overprovisioning-check-to-be-disabled.patch
+++ b/0005-Allow-overprovisioning-check-to-be-disabled.patch
@@ -1,0 +1,36 @@
+From de95b3a8192a18f1f8330fe2bb40054c4988a886 Mon Sep 17 00:00:00 2001
+Message-Id: <ffacf430755fe39052937234de79fe7ca1b2ff52.1666072612.git.demi@invisiblethingslab.com>
+In-Reply-To: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+References: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 1 Apr 2022 18:42:19 -0400
+Subject: [PATCH 5/6] Allow overprovisioning check to be disabled
+
+This check causes problems for Qubes OS.  Qubes OS treats lvm writing
+anything to stderr as an error, but the overprovisioning message is
+printed anyway, so Qubes OS must explicitly check for it.  It is simpler
+to just not produce the message in the first place.
+---
+ lib/metadata/thin_manip.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/lib/metadata/thin_manip.c b/lib/metadata/thin_manip.c
+index 0704f2bc36f91f2348fc264a9b309c17d3561184..7f79fc01e49b25aad089033295f59db7c194fc01 100644
+--- a/lib/metadata/thin_manip.c
++++ b/lib/metadata/thin_manip.c
+@@ -307,6 +307,10 @@ int pool_check_overprovisioning(const struct logical_volume *lv)
+ 	int percent, min_percent = 100;
+ 	int more_pools = 0;
+ 
++	/* Check if user has disabled overprovisioning warnings */
++	if (getenv("LVM_NO_OVERPROVISIONING_CHECK"))
++		return 1;
++
+ 	/* When passed thin volume, check related pool first */
+ 	if (lv_is_thin_volume(lv))
+ 		pool_lv = first_seg(lv)->pool_lv;
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/0006-Do-not-write-to-already-errored-stream.patch
+++ b/0006-Do-not-write-to-already-errored-stream.patch
@@ -1,0 +1,51 @@
+From b5e22596184664f811e359700a8248d56220385c Mon Sep 17 00:00:00 2001
+Message-Id: <f13ec12b59ba006ae177b0d9e041d908293792fa.1666072612.git.demi@invisiblethingslab.com>
+In-Reply-To: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+References: <9d96ef018178fb73bc4a4aba121d49e453cc9796.1666072612.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Tue, 18 Oct 2022 00:43:30 -0400
+Subject: [PATCH 6/6] Do not write to already errored stream
+
+If a stream has errored, writing further to it will just corrupt it.
+This ensures that e.g. errors writing JSON output will cause invalid
+JSON to be written.
+---
+ libdm/libdm-common.c | 10 ++++++++--
+ 1 file changed, 8 insertions(+), 2 deletions(-)
+
+diff --git a/libdm/libdm-common.c b/libdm/libdm-common.c
+index d75c7046c811e3b755a00a667c09c7758ef22b1e..d02b753129c883b701d34849012edfe8c321db0d 100644
+--- a/libdm/libdm-common.c
++++ b/libdm/libdm-common.c
+@@ -122,18 +122,24 @@ static void _default_log_line(int level, const char *file,
+ 		if (level < _LOG_WARN)
+ 			out = stderr;
+ 
++		if (ferror(out))
++			goto io_error;
++
+ 		if (_debug_with_line_numbers < 0)
+ 			/* Set when env DM_DEBUG_WITH_LINE_NUMBERS is not "0" */
+ 			_debug_with_line_numbers =
+ 				strcmp(getenv("DM_DEBUG_WITH_LINE_NUMBERS") ? : "0", "0");
+ 
+ 		if (_debug_with_line_numbers)
+-			fprintf(out, "%s:%d     ", file, line);
++			if (fprintf(out, "%s:%d     ", file, line) < 0)
++				goto io_error;
+ 
+-		vfprintf(out, f, ap);
++		if (vfprintf(out, f, ap) < 0)
++			goto io_error;
+ 		fputc('\n', out);
+ 	}
+ 
++io_error:
+ 	if (_abort_on_internal_errors < 0)
+ 		/* Set when env DM_ABORT_ON_INTERNAL_ERRORS is not "0" */
+ 		_abort_on_internal_errors =
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/lvm2.spec.in
+++ b/lvm2.spec.in
@@ -62,6 +62,12 @@ Source0: ftp://sourceware.org/pub/lvm2/releases/LVM2.%{version}.tgz
 Patch0: lvm2-set-default-preferred_names.patch
 Patch1: lvm2-use-find_config_tree_array.patch
 Patch2: lvm2-set-default-global_filter.patch
+Patch3: 0001-dmsetup-splitname-udevflags-check-for-stdout-errors.patch
+Patch4: 0002-Disable-lvm2-udev-rules-if-dmsetup-splitname-fails.patch
+Patch5: 0003-Disable-udev-rules-if-udev-flags-can-t-be-obtained.patch
+Patch6: 0004-Drop-support-for-very-old-kernels.patch
+Patch7: 0005-Allow-overprovisioning-check-to-be-disabled.patch
+Patch8: 0006-Do-not-write-to-already-errored-stream.patch
 
 BuildRequires: gcc
 %if %{enable_testsuite}


### PR DESCRIPTION
These patches silence warnings that are not useful for Qubes OS and
harden the code against potentially security-sensitive error conditions
and misconfigurations.

See individual patches for details.